### PR TITLE
fix: 잘못 수정된 PostResponseDto 복원

### DIFF
--- a/src/main/java/com/example/feed/post/dto/response/PostResponseDto.java
+++ b/src/main/java/com/example/feed/post/dto/response/PostResponseDto.java
@@ -1,15 +1,11 @@
 package com.example.feed.post.dto.response;
 
-import com.example.feed.comment.dto.CommentSimpleResponseDto;
 import com.example.feed.post.Post;
-
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
-import java.util.List;
-
 
 /*
 정적팩토리 메서드 from() 메서드로만 생성: private 접근제어
@@ -27,22 +23,9 @@ public class PostResponseDto {
 
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
-    private List<CommentSimpleResponseDto> comments;
 
     //entity -> dto
-    public static PostResponseDto from(Post post, List<CommentSimpleResponseDto> comments) {
-        return new PostResponseDto(post.getId(),
-                post.getTitle(),
-                post.getContent(),
-                post.getUser().getId(),
-                post.getCreatedAt(),
-                post.getModifiedAt(),
-                comments);
-    }
-
-
-    // 댓글 없이 사용하는 곳 호환용 overload
     public static PostResponseDto from(Post post) {
-        return from(post, null);
+        return new PostResponseDto(post.getId(), post.getTitle(), post.getContent(), post.getUser().getId(), post.getCreatedAt(), post.getModifiedAt());
     }
 }


### PR DESCRIPTION
이전 커밋에서 실수로 PostResponseDto의 구조가 변경되어
기존에 다른 팀원이 구현한 버전으로 복원합니다.