### PR TITLE
Fix: 논리적 삭제된 댓글/게시물에 좋아요 방지

### DIFF
--- a/src/main/java/com/example/feed/like/LikeService.java
+++ b/src/main/java/com/example/feed/like/LikeService.java
@@ -111,12 +111,12 @@ public class LikeService {
     }
 
     private Post findPostById(Long postId) {
-        return postRepository.findById(postId)
+        return postRepository.findByIdAndDeletedFalse(postId)
                 .orElseThrow(() -> new PostNotFoundException("게시물을 찾을 수 없습니다."));
     }
 
     private Comment findCommentById(Long commentId) {
-        return commentRepository.findById(commentId)
+        return commentRepository.findByIdAndDeletedFalse(commentId)
                 .orElseThrow(() -> new CommentNotFoundException("댓글을 찾을 수 없습니다."));
     }
 }


### PR DESCRIPTION
## 문제
삭제된 댓글/게시물에도 좋아요를 누를 수 있는 버그

## 해결
LikeService에서 `findById()` → `findByIdAndDeletedFalse()` 로 변경

## 변경 파일
- `LikeService.java` - findCommentById, findPostById 메서드 수정

## 결과
삭제된 댓글/게시물에 좋아요 시도 시 예외 발생